### PR TITLE
Add python linters in pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: 'v4.0.1'
     hooks:
       - id: trailing-whitespace
       - id: check-merge-conflict
@@ -12,9 +12,20 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.25.0
+    rev: 'v1.26.3'
     hooks:
       - id: yamllint
         files: \.(yaml|yml)$
         types: [file, yaml]
         entry: yamllint --strict
+
+  - repo: https://github.com/ambv/black
+    rev: 21.9b0
+    hooks:
+      - id: black
+        language_version: python3.9
+
+  - repo: https://github.com/pycqa/flake8
+    rev: '3.9.2'
+    hooks:
+      - id: flake8

--- a/runner.py
+++ b/runner.py
@@ -8,15 +8,16 @@ from pathlib import Path
 
 LOG = logging.getLogger(__name__)
 
-RUNNER_PLAYBOOK = config('RUNNER_PLAYBOOK', default='playbook.yml')
-RUNNER_ARTIFACT_DIR = config('RUNNER_ARTIFACT_DIR', default='artifacts')
-RUNNER_KEEP_ARTIFACTS = config('RUNNER_KEEP_ARTIFACTS', cast=int, default=10)
-RUNNER_INTERVAL = config('RUNNER_INTERVAL', cast=int, default=300)
-RUNNER_SKIPFILE = config('RUNNER_SKIPFILE', default=None)
-RUNNER_LOGLEVEL = config('RUNNER_LOGLEVEL', cast=int, default=0)
+RUNNER_DATA_DIR = config("RUNNER_DATA_DIR", default=".")
+RUNNER_PLAYBOOK = config("RUNNER_PLAYBOOK", default="playbook.yml")
+RUNNER_ARTIFACT_DIR = config("RUNNER_ARTIFACT_DIR", default="artifacts")
+RUNNER_KEEP_ARTIFACTS = config("RUNNER_KEEP_ARTIFACTS", cast=int, default=10)
+RUNNER_INTERVAL = config("RUNNER_INTERVAL", cast=int, default=300)
+RUNNER_SKIPFILE = config("RUNNER_SKIPFILE", default=None)
+RUNNER_LOGLEVEL = config("RUNNER_LOGLEVEL", cast=int, default=0)
 
 if RUNNER_SKIPFILE:
-    LOG.info('using skipfile %s', RUNNER_SKIPFILE)
+    LOG.info("using skipfile %s", RUNNER_SKIPFILE)
     skip_file = Path(RUNNER_SKIPFILE)
 else:
     skip_file = None
@@ -24,33 +25,34 @@ else:
 
 def run_playbook():
     if skip_file is not None and skip_file.exists():
-        LOG.warning('skip file exists, skipping this run')
+        LOG.warning("skip file exists, skipping this run")
         return
 
-    LOG.info('run playbook %s', RUNNER_PLAYBOOK)
+    LOG.info("run playbook %s", RUNNER_PLAYBOOK)
     res = ansible_runner.run(
-            private_data_dir='.',
-            playbook=RUNNER_PLAYBOOK,
-            artifact_dir=RUNNER_ARTIFACT_DIR,
-            rotate_artifacts=RUNNER_KEEP_ARTIFACTS)
-    LOG.info('finished playbook %s, exit code = %d',
-            RUNNER_PLAYBOOK, res.rc)
+        private_data_dir=RUNNER_DATA_DIR,
+        playbook=RUNNER_PLAYBOOK,
+        artifact_dir=RUNNER_ARTIFACT_DIR,
+        rotate_artifacts=RUNNER_KEEP_ARTIFACTS,
+    )
+    LOG.info("finished playbook %s, exit code = %d", RUNNER_PLAYBOOK, res.rc)
 
 
 def main():
-    loglevel = ['WARNING', 'INFO', 'DEBUG'][min(RUNNER_LOGLEVEL, 2)]
+    loglevel = ["WARNING", "INFO", "DEBUG"][min(RUNNER_LOGLEVEL, 2)]
     logging.basicConfig(
-            level=loglevel,
-            datefmt='%Y-%m-%d %H:%M:%S',
-            format='%(asctime)s %(levelname)s %(message)s')
+        level=loglevel,
+        datefmt="%Y-%m-%d %H:%M:%S",
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
 
     schedule.every(RUNNER_INTERVAL).seconds.do(run_playbook)
 
-    LOG.info('starting scheduler (interval=%d seconds)', RUNNER_INTERVAL)
+    LOG.info("starting scheduler (interval=%d seconds)", RUNNER_INTERVAL)
     while True:
         schedule.run_pending()
         time.sleep(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Update .pre-commit-config.yaml to include the `black` and `flake8`
linters, and correct any errors they emit.
