### PR TITLE
Add support for projects with no quota

### DIFF
--- a/.github/workflows/precommit.yaml
+++ b/.github/workflows/precommit.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v2
         with:
-          python-version: '^3.9'
+          python-version: '3.9'
 
       - name: Install pre-commit
         run: |

--- a/roles/openshift_project/tasks/create-project.yaml
+++ b/roles/openshift_project/tasks/create-project.yaml
@@ -1,10 +1,12 @@
-- name: "{{ project_name }} : verify that quota exists"
-  file:
-    path: quotas/{{ project_data.quota|default(default_quota) }}/resourcequota.yaml
-
 - name: "{{ project_name }} : display project information"
   debug:
     var: project_data
+
+- name: "{{ project_name }} : verify that quota exists"
+  when: >-
+    project_data.quota != "no-quota"
+  file:
+    path: quotas/{{ project_data.quota|default(default_quota) }}/resourcequota.yaml
 
 - name: "{{ project_name }} : create namespace"
   kubernetes.core.k8s:
@@ -21,30 +23,33 @@
         labels:
           massopen.cloud/project: "{{ project_name }}"
 
-- name: "{{ project_name }} : create limitrange"
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      kind: LimitRange
-      apiVersion: v1
-      metadata:
-        name: default
-        namespace: "{{ project_name }}"
-      spec:
-        limits:
-          - type: Container
-            default:
-              cpu: "1"
-              memory: "2Gi"
-            defaultRequest:
-              cpu: "500m"
-              memory: "500Mi"
+- when: >-
+    project_data.quota != "no-quota"
+  block:
+    - name: "{{ project_name }} : create limitrange"
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          kind: LimitRange
+          apiVersion: v1
+          metadata:
+            name: default
+            namespace: "{{ project_name }}"
+          spec:
+            limits:
+              - type: Container
+                default:
+                  cpu: "1"
+                  memory: "2Gi"
+                defaultRequest:
+                  cpu: "500m"
+                  memory: "500Mi"
 
-- name: "{{ project_name }} : create quota"
-  kubernetes.core.k8s:
-    state: present
-    namespace: "{{ project_name }}"
-    src: quotas/{{ project_data.quota|default(default_quota) }}/resourcequota.yaml
+    - name: "{{ project_name }} : create quota"
+      kubernetes.core.k8s:
+        state: present
+        namespace: "{{ project_name }}"
+        src: quotas/{{ project_data.quota|default(default_quota) }}/resourcequota.yaml
 
 - name: "{{ project_name }} : create admin group"
   kubernetes.core.k8s:


### PR DESCRIPTION
Support setting a project quota to the special value "no-quota":

    description: An example project
    requester: alice@example.com
    quota: no-quota
    admins:
    - alice@example.com

This will create the namespace and access groups but will not populate
the project with a quota or limitrange. This allows us to manage
custom quotas outside of the moc-openshift-projects repository.
